### PR TITLE
Refactor XWP\SiteCounts\Block::render_callback

### DIFF
--- a/php/Block.php
+++ b/php/Block.php
@@ -63,64 +63,115 @@ class Block {
 	 * @return string The markup of the block.
 	 */
 	public function render_callback( $attributes, $content, $block ) {
-		$post_types = get_post_types(  [ 'public' => true ] );
-		$class_name = $attributes['className'];
+		$attributes = wp_parse_args(
+			[
+				'className' => '',
+			],
+			$attributes
+		);
+
+		/**
+		 * Count all the post types.
+		 */
+		$post_types = get_post_types( [ 'public' => true ], 'objects' );
+		$counts     = [];
+
+		foreach ( $post_types as $post_type ) {
+			$count = wp_count_posts( $post_type->name );
+			if ( 'attachment' === $post_type->name ) {
+				// Attachments are always inherited as per get_posts.
+				$counts[ $post_type->name ] = $count->inherit;
+			} else {
+				$counts[ $post_type->name ] = $count->publish;
+			}
+		}
+
+		/**
+		 * Get up to 5 posts in foo-baz.
+		 */
+		$query = new WP_Query(
+			[
+				'posts_per_page'         => 5,
+				'post_type'              => [ 'post', 'page' ],
+				'post_status'            => 'any',
+				'tag'                    => 'foo',
+				'category_name'          => 'baz',
+				'post__not_in'           => [ get_the_ID() ],
+				'no_found_rows'          => true,
+				'update_post_meta_cache' => false,
+				'update_post_term_cache' => false,
+				'date_query'             => [
+					[
+						'hour'    => [ 9, 17 ],
+						'compare' => 'between',
+					],
+				],
+			]
+		);
+
 		ob_start();
 
 		?>
-        <div class="<?php echo $class_name; ?>">
-			<h2>Post Counts</h2>
-			<ul>
-			<?php
-			foreach ( $post_types as $post_type_slug ) :
-                $post_type_object = get_post_type_object( $post_type_slug  );
-                $post_count = count(
-                    get_posts(
-						[
-							'post_type' => $post_type_slug,
-							'posts_per_page' => -1,
-						]
-					)
-                );
+			<div class="<?php echo esc_attr( $attributes['class_name'] ); ?>">
+				<h2><?php esc_html_e( 'Post Counts', 'site-counts' ); ?></h2>
 
+				<ul>
+				<?php foreach ( $post_types as $post_type ) : ?>
+					<li>
+					<?php
+						echo esc_html(
+							sprintf(
+								/* translators: %1$d is replaced with the number of entries, %2$s is replaced with the post type general label */
+								__( 'There are %1$d %2$s.', 'site-counts' ),
+								$counts[ $post_type->name ],
+								$post_type->labels->name
+							)
+						);
+					?>
+					</li>
+				<?php endforeach; ?>
+				</ul>
+
+				<p>
+				<?php
+					echo esc_html(
+						sprintf(
+							/* translators: %d is replaced with post ID */
+							__( 'The current post ID is %d.', 'site-counts' ),
+							get_the_ID()
+						)
+					);
 				?>
-				<li><?php echo 'There are ' . $post_count . ' ' .
-					  $post_type_object->labels->name . '.'; ?></li>
-			<?php endforeach;	?>
-			</ul><p><?php echo 'The current post ID is ' . $_GET['post_id'] . '.'; ?></p>
+				</p>
 
-			<?php
-			$query = new WP_Query(  array(
-				'post_type' => ['post', 'page'],
-				'post_status' => 'any',
-				'date_query' => array(
-					array(
-						'hour'      => 9,
-						'compare'   => '>=',
-					),
-					array(
-						'hour' => 17,
-						'compare'=> '<=',
-					),
-				),
-                'tag'  => 'foo',
-                'category_name'  => 'baz',
-				  'post__not_in' => [ get_the_ID() ],
-			));
-
-			if ( $query->have_posts() ) :
-				?>
-				 <h2>5 posts with the tag of foo and the category of baz</h2>
-                <ul>
-                <?php
-
-                 foreach ( array_slice( $query->posts, 0, 5 ) as $post ) :
-                    ?><li><?php echo $post->post_title ?></li><?php
-				endforeach;
-			endif;
-		 	?>
-			</ul>
-		</div>
+				<?php if ( $query->have_posts() ) : ?>
+					<h2>
+						<?php
+							echo esc_html(
+								sprintf(
+									/* translators: %1$d is the number of posts, %2$s and %3$s are the name of the tag and category */
+									_n(
+										'%1$d post with the tag of %2$s and the category of %3$s',
+										'%1$d posts with the tag of %2$s and the category of %3$s',
+										$query->post_count,
+										'site-counts'
+									),
+									$query->post_count,
+									$query->query_vars['tag'],
+									$query->query_vars['category_name']
+								)
+							);
+						?>
+					</h2>
+					<ul>
+						<?php while ( $query->have_posts() ) : ?>
+							<?php $query->the_post(); ?>
+							<li><?php the_title(); ?></li>
+						<?php endwhile; ?>
+					</ul>
+					<?php wp_reset_postdata(); ?>
+				<?php endif; ?>
+			</div>
 		<?php
 
 		return ob_get_clean();


### PR DESCRIPTION
This is a major overhaul of the `XWP\SiteCounts\Block::render_callback` method. Beyond improving readability, maintainability and structure, a couple of important performance and security fixes have been made.

1. All dynamic output (including translated strings) is now escaped.
2. `wp_count_posts` is now used to get post counts.
3. Added `posts_per_page` to `WP_Query` to limit fetching to 5 posts.
4. Removed 3 extra SQL queries from `WP_Query` by enabling `no_found_rows`, and disabling `update_post_meta_cache`, `update_post_term_cache`.

A couple of other improvements have been made:

1. "The Loop" has been refactored to a more traditional form.
2. Translations have been added, although could be improved.
3. WordPress Coding Standards (VIP) have been applied.

Several other areas of improvement can be made in further passes:

1. Tests are now borken.
2. Fragment caching could be attempted, but not without further profiling and benchmarking (premature optimization is the root of all evil).
3. The `_n` translation functions for post type labels is tricky in languages where there are more than one plural form.